### PR TITLE
Fix deprecated function

### DIFF
--- a/R/patient_tracker_extract_helper.R
+++ b/R/patient_tracker_extract_helper.R
@@ -141,7 +141,7 @@ extract_date_from_measurement_column <- function(patient_df, colname) {
     colname_value <- paste(c(colname, ""), collapse = "")
     colname_core <- sub("[_][^_]+$", "", colname) # remove last element after "_"
     colname_date <- paste(c(colname_core, "_date"), collapse = "")
-    patient_df <- separate_(
+    patient_df <- separate(
         data = patient_df, col = colname,
         into = c(colname_value, colname_date), sep = "([(])"
     )


### PR DESCRIPTION
Replaced the deprecated `tidyr::separate_()` with the new function `tidyr::separate()`.
This will remove a warning and will prevent the code from breaking in the future.