### PR TITLE
Add new date column based on tracker_year and tracker_month

### DIFF
--- a/scripts/run_script_2_clean_data.R
+++ b/scripts/run_script_2_clean_data.R
@@ -203,6 +203,7 @@ process_patient_file <- function(paths, patient_file, patient_file_name, output_
         t1d_diagnosis_date = lubridate::as_date(1),
         t1d_diagnosis_with_dka = character(),
         testing_frequency = integer(),
+        tracker_date = lubridate::as_date(1),
         tracker_month = integer(),
         tracker_year = integer(),
         updated_2022_date = lubridate::as_date(1),
@@ -275,6 +276,7 @@ process_patient_file <- function(paths, patient_file, patient_file_name, output_
             fbg_updated_mmol = cut_numeric_value(fbg_updated_mmol, min = 0, max = 136.5, "fbg_updated_mmol"),
             blood_pressure_sys_mmhg = cut_numeric_value(blood_pressure_sys_mmhg, min = 20, max = 250, "blood_pressure_sys_mmhg"),
             blood_pressure_dias_mmhg = cut_numeric_value(blood_pressure_dias_mmhg, min = 20, max = 220, "blood_pressure_dias_mmhg"),
+            tracker_date = lubridate::ym(paste(tracker_year, tracker_month, sep="-")),
             !!!parse_character_cleaning_config(a4d:::config$cleaning),
             # should be fixed last as other fix functions use id to log invalid rows!
             id = fix_id(id)


### PR DESCRIPTION
use `lubridate::ym` to create a valid date value from `tracker_year` and `tracker_month` in the form "XXXX-X", which will always use day 1 

I added this to the different column vectors in the create table functions for script 3 and uploaded the parquet files to BQ and the new column `tracker_date` is there and recognized as DATE

closes #100 